### PR TITLE
Deafen when joining a channel

### DIFF
--- a/mrvn-back-ytdl/src/speaker.rs
+++ b/mrvn-back-ytdl/src/speaker.rs
@@ -185,6 +185,13 @@ impl<'handle> GuildSpeakerRef<'handle> {
                 }
 
                 let mut call = call_handle.lock().await;
+                if !call.is_deaf() {
+                    let deafen_res = call.deafen(true).await;
+                    if let Err(why) = deafen_res {
+                        self.guild_speaker.playing_state = None;
+                        return Err(crate::Error::SongbirdJoin(why));
+                    }
+                }
                 call.remove_all_global_events();
                 call.add_global_event(
                     songbird::Event::Core(songbird::CoreEvent::DriverDisconnect),


### PR DESCRIPTION
PR to ensure that the bot is always deafened (gives peace and mind from a privacy perspective, shouldn't have any cost since nothing in the bot requires listening to other users). I thought about putting this behind a config flag as well, but I couldn't see a reason to have the bot not do this.